### PR TITLE
node-app-test-pipeline to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: node-app-test-pipeline
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2


### PR DESCRIPTION
Promote node-app-test-pipeline to version 0.0.2